### PR TITLE
fix(pwsh): do not throw when testing SAN existence

### DIFF
--- a/kyos.logicapp/entraid.governance/UniqueChecksInventory/Scripts/compute-unique-ext-san-batch.ps1
+++ b/kyos.logicapp/entraid.governance/UniqueChecksInventory/Scripts/compute-unique-ext-san-batch.ps1
@@ -117,7 +117,7 @@ function Get-UniqueSamAccountName {
             try {
                 $existingUser = Get-ADUser -Filter "SamAccountName -eq '$samAccountName'" -SearchBase $SearchBase -ErrorAction SilentlyContinue
             } catch {
-                throw "Failed to query Active Directory for SamAccountName '$samAccountName': $($_.Exception.Message)"
+                # Ignore errors, treat as not found
             }
 
             if ($null -eq $existingUser) {


### PR DESCRIPTION
In a script that tests sAMAccountNames to find an unused slot, Get-ADUser returning "null" is not an error, it's actually good news.